### PR TITLE
Remove redundant type comments and fix format

### DIFF
--- a/prefixspan-cli
+++ b/prefixspan-cli
@@ -26,7 +26,7 @@ Options:
     --maxlen=<maxlen>  Maximum length of patterns. [default: 1000]
 """
 
-from typing import *
+from typing import Callable, Dict
 
 import sys
 
@@ -36,8 +36,8 @@ from prefixspan import PrefixSpan
 from extratools.dicttools import invert, remap
 from extratools.printtools import print2
 
-def checkArg(arg, cond):
-    # type: (str, Callable[[int], bool]) -> int
+
+def checkArg(arg: str, cond: Callable[[int], bool]) -> int:
     try:
         val = int(argv[arg])
         if not cond(val):
@@ -50,8 +50,7 @@ def checkArg(arg, cond):
     return val
 
 
-def checkFunc(arg):
-    # type: (str) -> Callable[..., bool]
+def checkFunc(arg: str) -> Callable[..., bool]:
     try:
         return eval(argv[arg])
     except:
@@ -71,7 +70,7 @@ if __name__ == "__main__":
     ]
 
     if istext:
-        wordmap = {} # type: Dict[str, int]
+        wordmap: Dict[str, int] = {}
 
         db = [list(remap(doc, wordmap)) for doc in docs]
     else:
@@ -99,15 +98,14 @@ if __name__ == "__main__":
     if argv["--maxlen"]:
         ps.maxlen = checkArg("--maxlen", lambda v: v >= ps.minlen)
 
-
     if istext:
         invwordmap = invert(wordmap)
 
     for freq, patt in func(
-            threshold, closed=closed, generator=generator,
-            key=key, bound=bound,
-            filter=filter
-        ):
+        threshold, closed=closed, generator=generator,
+        key=key, bound=bound,
+        filter=filter
+    ):
         print("{} : {}".format(' '.join(
             (invwordmap[i] for i in patt) if istext
             else (str(i) for i in patt)

--- a/prefixspan/closed.py
+++ b/prefixspan/closed.py
@@ -1,12 +1,11 @@
 #! /usr/bin/env python3
 
-from .localtyping import *
+from .localtyping import Optional, Set, Matches, DB, Pattern, List
 
-def __reversescan(db, patt, matches):
-    # type: (DB, List[Optional[int]], Matches) -> bool
-    def islocalclosed(previtem):
-        # type: (Optional[int]) -> bool
-        closeditems = set() # type: Set[int]
+
+def __reversescan(db: DB, patt: List[Optional[int]], matches: Matches):
+    def islocalclosed(previtem: Optional[int]) -> bool:
+        closeditems: Set[int] = set()
 
         for k, (i, endpos) in enumerate(matches):
             localitems = set()
@@ -20,16 +19,15 @@ def __reversescan(db, patt, matches):
 
                 localitems.add(item)
 
-            (closeditems.update if k == 0 else closeditems.intersection_update)(localitems)
+            (closeditems.update if k ==
+             0 else closeditems.intersection_update)(localitems)
 
         return len(closeditems) > 0
-
 
     return any(islocalclosed(previtem) for previtem in reversed(patt[:-1]))
 
 
-def isclosed(db, patt, matches):
-    # type: (DB, Pattern, Matches) -> bool
+def isclosed(db: DB, patt: Pattern, matches: Matches) -> bool:
     # Add a pseduo item indicating the start of sequence
     # Add a pseduo item indicating the end of sequence
     return not __reversescan(
@@ -39,7 +37,6 @@ def isclosed(db, patt, matches):
     )
 
 
-def canclosedprune(db, patt, matches):
-    # type: (DB, Pattern, Matches) -> bool
+def canclosedprune(db: DB, patt: Pattern, matches: Matches) -> bool:
     # Add a pseduo item indicating the start of sequence
     return __reversescan(db, [None, *patt], matches[:])

--- a/prefixspan/closed.py
+++ b/prefixspan/closed.py
@@ -19,8 +19,8 @@ def __reversescan(db: DB, patt: List[Optional[int]], matches: Matches):
 
                 localitems.add(item)
 
-            (closeditems.update if k ==
-             0 else closeditems.intersection_update)(localitems)
+            (closeditems.update if k == 0
+             else closeditems.intersection_update)(localitems)
 
         return len(closeditems) > 0
 

--- a/prefixspan/frequent.py
+++ b/prefixspan/frequent.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python3
 
-from .localtyping import *
+from .localtyping import Results, Optional, Key, Callback, Filter, Pattern, Matches, List, Occurs
 
 from extratools.dicttools import nextentries
 
@@ -8,38 +8,34 @@ from .prefixspan import PrefixSpan
 from .closed import isclosed, canclosedprune
 from .generator import isgenerator, cangeneratorprune
 
-def PrefixSpan_frequent(
-        self, minsup, closed=False, generator=False,
-        key=None, bound=None,
-        filter=None, callback=None
-    ):
-    # type: (PrefixSpan, int, bool, bool, Optional[Key], Optional[Key], Optional[Filter], Optional[Callback]) -> Results
-    if generator:
-        occursstack = [] # type: List[Occurs]
 
-    def canpass(sup):
-        # type: (int) -> bool
+def PrefixSpan_frequent(
+    self, minsup: int, closed=False, generator=False,
+    key: Optional[Key] = None, bound: Optional[Key] = None,
+    filter: Optional[Filter] = None, callback: Optional[Callback] = None
+) -> Results:
+    if generator:
+        occursstack: List[Occurs] = []
+
+    def canpass(sup: int) -> bool:
         return sup < minsup
 
-
-    def verify(patt, matches):
-        # type: (Pattern, Matches) -> None
+    def verify(patt: Pattern, matches: Matches) -> None:
         sup = key(patt, matches)
         if canpass(sup):
             return
 
         if (filter is None or filter(patt, matches)) and (
-                (not closed or isclosed(self._db, patt, matches)) and
-                (not generator or isgenerator(self._db, patt, matches, occursstack))
-            ):
+            (not closed or isclosed(self._db, patt, matches)) and
+            (not generator or isgenerator(
+                self._db, patt, matches, occursstack))
+        ):
             if callback:
                 callback(patt, matches)
             else:
                 self._results.append((sup, patt))
 
-
-    def frequent_rec(patt, matches):
-        # type: (Pattern, Matches) -> None
+    def frequent_rec(patt: Pattern, matches: Pattern) -> None:
         if len(patt) >= self.minlen:
             verify(patt, matches)
 
@@ -53,16 +49,16 @@ def PrefixSpan_frequent(
         for newitem, newmatches in occurs.items():
             newpatt = patt + [newitem]
             if canpass(bound(newpatt, newmatches)) or (
-                    closed and canclosedprune(self._db, newpatt, newmatches) or
-                    generator and cangeneratorprune(self._db, newpatt, newmatches, occursstack)
-                ):
+                closed and canclosedprune(self._db, newpatt, newmatches) or
+                generator and cangeneratorprune(
+                    self._db, newpatt, newmatches, occursstack)
+            ):
                 continue
 
             frequent_rec(newpatt, newmatches)
 
         if generator:
             occursstack.pop()
-
 
     if key is None:
         key = bound = PrefixSpan.defaultkey

--- a/prefixspan/frequent.py
+++ b/prefixspan/frequent.py
@@ -20,7 +20,7 @@ def PrefixSpan_frequent(
     def canpass(sup: int) -> bool:
         return sup < minsup
 
-    def verify(patt: Pattern, matches: Matches) -> None:
+    def verify(patt: Pattern, matches: Matches):
         sup = key(patt, matches)
         if canpass(sup):
             return
@@ -35,7 +35,7 @@ def PrefixSpan_frequent(
             else:
                 self._results.append((sup, patt))
 
-    def frequent_rec(patt: Pattern, matches: Pattern) -> None:
+    def frequent_rec(patt: Pattern, matches: Pattern):
         if len(patt) >= self.minlen:
             verify(patt, matches)
 
@@ -48,11 +48,10 @@ def PrefixSpan_frequent(
 
         for newitem, newmatches in occurs.items():
             newpatt = patt + [newitem]
-            if canpass(bound(newpatt, newmatches)) or (
-                closed and canclosedprune(self._db, newpatt, newmatches) or
-                generator and cangeneratorprune(
-                    self._db, newpatt, newmatches, occursstack)
-            ):
+
+            if canpass(bound(newpatt, newmatches)) or\
+                (closed and canclosedprune(self._db, newpatt, newmatches)) or\
+                    (generator and cangeneratorprune(self._db, newpatt, newmatches, occursstack)):
                 continue
 
             frequent_rec(newpatt, newmatches)

--- a/prefixspan/generator.py
+++ b/prefixspan/generator.py
@@ -1,17 +1,17 @@
 #! /usr/bin/env python3
 
-from .localtyping import *
+from .localtyping import DB, Pattern, Matches, List, Occurs
 
 from extratools.seqtools import issubseqwithgap
 from extratools.sortedtools import sorteddiff
 
-def isgenerator(db, patt, matches, occursstack):
-    # type: (DB, Pattern, Matches, List[Occurs]) -> bool
+
+def isgenerator(db: DB, patt: Pattern, matches: Matches, occursstack: List[Occurs]):
     # Try to remove the last item
     if (
-            len(db) if len(patt) < 2
-            else len(occursstack[len(patt) - 2][patt[-2]])
-        ) == len(matches):
+        len(db) if len(patt) < 2
+        else len(occursstack[len(patt) - 2][patt[-2]])
+    ) == len(matches):
         return False
 
     for i in range(len(patt) - 1, 0, -1):
@@ -21,16 +21,15 @@ def isgenerator(db, patt, matches, occursstack):
         # occursstack[0] is for patt == []
         prevoccurs, occurs = occursstack[i - 1][item], occursstack[i][item]
         if len(prevoccurs) == len(occurs) or all(
-                not issubseqwithgap(patt[i + 1:], db[k][pos + 1:])
-                for k, pos in sorteddiff(prevoccurs, occurs, key=lambda x: x[0])
-            ):
+            not issubseqwithgap(patt[i + 1:], db[k][pos + 1:])
+            for k, pos in sorteddiff(prevoccurs, occurs, key=lambda x: x[0])
+        ):
             return False
 
     return True
 
 
-def cangeneratorprune(db, patt, matches, occursstack):
-    # type: (DB, Pattern, Matches, List[Occurs]) -> bool
+def cangeneratorprune(db: DB, patt: Pattern, matches: Matches, occursstack: List[Occurs]) -> bool:
     for i in range(len(patt) - 1, 0, -1):
         # Try to remove the (i-1)-th item
         item = patt[i]

--- a/prefixspan/localtyping.py
+++ b/prefixspan/localtyping.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python3
 
-from typing import *
+from typing import List, Tuple, Dict, Optional, Callable, Set, Any
 
 DB = List[List[int]]
 

--- a/prefixspan/prefixspan.py
+++ b/prefixspan/prefixspan.py
@@ -1,27 +1,26 @@
 #! /usr/bin/env python3
 
-from .localtyping import *
+from .localtyping import List, Callable, Matches, Pattern, Any
+
 
 class PrefixSpan(object):
-    def __init__(self, db):
-        # type: (List[List[int]]) -> None
+    def __init__(self, db: List[List[int]]):
         self._db = db
 
         self.minlen, self.maxlen = 1, 1000
 
-        self._results = [] # type: Any
+        self._results: Any = []
 
-
-    def _mine(self, func):
-        # type: (Callable[[Pattern, Matches], None]) -> Any
+    def _mine(self, func: Callable[[Pattern, Matches], None]) -> Any:
         self._results.clear()
 
         func([], [(i, -1) for i in range(len(self._db))])
 
         return self._results
 
+    frequent: Callable = None
+    topk: Callable = None
 
-    frequent = None # type: Callable
-    topk = None # type: Callable
-
-    defaultkey = lambda patt, matches: len(matches)
+    @staticmethod
+    def defaultkey(patt, matches):
+        return len(matches)

--- a/prefixspan/topk.py
+++ b/prefixspan/topk.py
@@ -1,6 +1,6 @@
 #! /usr/bin/env python3
 
-from .localtyping import *
+from .localtyping import Pattern, Matches, Optional, Key, Filter, Callback, Results, List, Occurs
 
 from heapq import heappush, heappushpop
 
@@ -10,35 +10,32 @@ from .prefixspan import PrefixSpan
 from .closed import isclosed, canclosedprune
 from .generator import isgenerator, cangeneratorprune
 
-def PrefixSpan_topk(
-        self, k, closed=False, generator=False,
-        key=None, bound=None,
-        filter=None, callback=None
-    ):
-    # type: (PrefixSpan, int, bool, bool, Optional[Key], Optional[Key], Optional[Filter], Optional[Callback]) -> Results
-    if generator:
-        occursstack = [] # type: List[Occurs]
 
-    def canpass(sup):
-        # type: (int) -> bool
+def PrefixSpan_topk(
+    self: PrefixSpan, k: int, closed=False, generator=False,
+    key: Optional[Key] = None, bound: Optional[Key] = None,
+    filter: Optional[Filter] = None, callback: Optional[Callback] = None
+) -> Results:
+    if generator:
+        occursstack: List[Occurs] = []
+
+    def canpass(sup: int) -> bool:
         return len(self._results) == k and sup <= self._results[0][0]
 
-
-    def verify(patt, matches):
-        # type: (Pattern, Matches) -> None
+    def verify(patt: Pattern, matches: Matches):
         sup = key(patt, matches)
         if canpass(sup):
             return
 
         if (filter is None or filter(patt, matches)) and (
-                (not closed or isclosed(self._db, patt, matches)) and
-                (not generator or isgenerator(self._db, patt, matches, occursstack))
-            ):
-            (heappush if len(self._results) < k else heappushpop)(self._results, (sup, patt, matches))
+            (not closed or isclosed(self._db, patt, matches)) and
+            (not generator or isgenerator(
+                self._db, patt, matches, occursstack))
+        ):
+            (heappush if len(self._results) < k else heappushpop)(
+                self._results, (sup, patt, matches))
 
-
-    def topk_rec(patt, matches):
-        # type: (Pattern, Matches) -> None
+    def topk_rec(patt: Pattern, matches: Matches):
         if len(patt) >= self.minlen:
             verify(patt, matches)
 
@@ -50,26 +47,26 @@ def PrefixSpan_topk(
             occursstack.append(occurs)
 
         for newitem, newmatches in sorted(
-                occurs.items(),
-                key=lambda x: key(patt + [x[0]], x[1]),
-                reverse=True
-            ):
+            occurs.items(),
+            key=lambda x: key(patt + [x[0]], x[1]),
+            reverse=True
+        ):
             newpatt = patt + [newitem]
 
             if canpass(bound(newpatt, newmatches)):
                 break
 
             if (
-                    closed and canclosedprune(self._db, newpatt, newmatches) or
-                    generator and cangeneratorprune(self._db, newpatt, newmatches, occursstack)
-                ):
+                closed and canclosedprune(self._db, newpatt, newmatches) or
+                generator and cangeneratorprune(
+                    self._db, newpatt, newmatches, occursstack)
+            ):
                 continue
 
             topk_rec(newpatt, newmatches)
 
         if generator:
             occursstack.pop()
-
 
     if key is None:
         key = bound = PrefixSpan.defaultkey


### PR DESCRIPTION
Thank you for developing a useful package.  I am using this frequently.
I add type helper instead of comments, it helps me to understand when I call this by import.