### PR TITLE
fixed wordmap generation for text input

### DIFF
--- a/prefixspan-cli
+++ b/prefixspan-cli
@@ -72,8 +72,15 @@ if __name__ == "__main__":
 
     if istext:
         wordmap = {} # type: Dict[str, int]
-
-        db = [list(remap(doc, wordmap)) for doc in docs]
+        for doc in docs:
+            for word in doc:
+                if not word in wordmap:
+                    wordmap[word] = len(wordmap)
+        db = [
+            [wordmap[w] for w in doc]
+            for doc in docs
+        ]
+        
     else:
         db = [
             [int(w) for w in doc]


### PR DESCRIPTION
As first raised by https://github.com/chuanconggao/PrefixSpan-py/issues/24 , wordmap generation was not working property. This seems to fix it. 